### PR TITLE
Added validation for base URL

### DIFF
--- a/ApiClient.php
+++ b/ApiClient.php
@@ -11,6 +11,11 @@ class ApiClient {
 
     public function __construct(string $api_key, string $base_url="https://cockpit.shirtigo.de/api/")
     {
+	// Validate base URL
+	if (substr($base_url, -1) !== '/' ) {
+            throw new \InvalidArgumentException('Invalid API base URL. The URL has to end with a backslash.');
+        }
+	    
     	// initialize GuzzleHttp client
         $this->client = new Client([
             'verify' => false,


### PR DESCRIPTION
API calls won't work without the blackslash at the end of the base URL, and they won't cause a proper error message, so it's one of these confusing issuses that no one wants to deal with... better to catch it and return a meaningful exception!

_Alternative_:
Do not throw an exception but fix it silently.
```PHP
	// Validate base URL
	if (substr($base_url, -1) !== '/' ) {
            $base_url .= '/';
        }    
```

( Also refers to this: https://github.com/Shirtigo/shirtigo-api-php/pull/4 )