### PR TITLE
Do not try to access an array that doesn't exist

### DIFF
--- a/ApiClient.php
+++ b/ApiClient.php
@@ -54,7 +54,7 @@ class ApiClient {
                 throw new \RuntimeException("{$method} is not valid a valid HTTP verb for the '{$url}' endpoint.");
             } else if ($status == 422) {
         	    $json = json_decode($body, true);
-        	    $message = json_encode($json['errors']);
+        	    $message = isset($json['errors']) ? json_encode($json['errors']) : $json['message'];
         	    throw new \RuntimeException("Input validation failed: {$message}");
             } else {
                 $json = json_decode($body, true);


### PR DESCRIPTION
The original code assumed that all reponses with HTTP code 442 look like his:

```
{
  "type": "UnprocessableEntityHttpException",
  "message": "The given data failed to pass validation.",
  "status": 422,
  "errors": {
    "firstname": [
      "The firstname field is required."
    ]
  }
}
```

If the structure of the response object is different a notice will be caused.
To prevent this, check if the `errors` property exists and in case it does not, use the `message` instead.

PS: Regardless of this pull request we might consider to change the response of the design upload API endpoint when an invalid image is uploaded so that it returns and array of validation error descriptions.